### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,23 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      actions:
+        patterns:
+          - '*'
 
+  # One PR per group rather than one per package: everything here is tooling
+  # around a single runtime dependency, @actions/core.
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    groups:
+      dependencies:
+        dependency-type: production
+        patterns:
+          - '*'
+      dev-dependencies:
+        dependency-type: development
+        patterns:
+          - '*'


### PR DESCRIPTION
# User description
Dependabot opens one PR per package, daily. This repo has one runtime dependency — `@actions/core` — and everything else is build and test tooling, so that is a steady trickle of PRs like #10 for things that cannot affect the published action.

Groups npm updates into a production and a development PR, and `actions/*` updates into one. Cadence stays daily.

Security updates are raised separately from version updates and are not affected by grouping — the three open alerts still get their own PRs if they are not already fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Group Dependabot&#x27;s npm updates into production and development PRs, and batch <code>actions/*</code> updates into a single daily group. Adjust the repository&#x27;s Dependabot configuration so the update bot keeps daily cadence without opening one PR per package.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/currents-dev/cancel-run-gh-action/12?tool=ast&topic=Npm+grouping>Npm grouping</a>
        </td><td>Separate production and development <code>npm</code> dependency updates into grouped PRs.<details><summary>Modified files (1)</summary><ul><li>.github/dependabot.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>chore: group dependabo...</td><td>July 26, 2026</td></tr>
<tr><td>vCaisim</td><td>Initial commit</td><td>May 22, 2023</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/currents-dev/cancel-run-gh-action/12?tool=ast&topic=Actions+grouping>Actions grouping</a>
        </td><td>Batch <code>actions/*</code> updates into a single grouped PR.<details><summary>Modified files (1)</summary><ul><li>.github/dependabot.yml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>agoldis@gmail.com</td><td>chore: group dependabo...</td><td>July 26, 2026</td></tr>
<tr><td>vCaisim</td><td>Initial commit</td><td>May 22, 2023</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/currents-dev/cancel-run-gh-action/12?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>